### PR TITLE
Remove setup_storage() on init

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -21,8 +21,6 @@ function init()
 
   if DEBUG then log("Setting up PlanetSelect") end
   PlanetSelect.setup_force()
-  if DEBUG then log("Setting up storage...") end
-  setup_storage()
   if DEBUG then log("Hiding Nauvis...") end
   game.forces.player.set_surface_hidden(game.surfaces.nauvis, true)
   game.forces.player.lock_space_location("nauvis");


### PR DESCRIPTION
Some modded planets register a hook for on_surface_created for their planet. For example, Muluna uses this hook to create starting cargo pods. Unfortunately their hook registration can be after planet picker performs init, and as a result the surface is created by planet picker before the planet mod can receive the event. In the case Muluna, the cargo pods are never spawned